### PR TITLE
feat: machine-definition option to enable auto-copying of state-data during transitions

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,6 @@
-export default { extends: ["@commitlint/config-conventional"] };
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "body-max-line-length": [2, "always", 120],
+  },
+};

--- a/packages/yay-machine/src/MachineState.ts
+++ b/packages/yay-machine/src/MachineState.ts
@@ -20,3 +20,19 @@ export type StateData<StateType extends MachineState<string>, Name extends State
 > extends never
   ? never
   : Omit<ExtractState<StateType, Name>, "name">;
+
+type ExpandStateDataTypes<StateType extends MachineState<string>> = {
+  [Name in StateType["name"]]: StateData<StateType, Name>;
+};
+
+type Values<T> = T[keyof T];
+
+type AllValuesCompatible<T> = Values<T> extends infer V
+  ? { [K in keyof T]: V extends T[K] ? true : false }[keyof T] extends true
+    ? true
+    : false
+  : false;
+
+export type IsStateDataHomogenous<StateType extends MachineState<string>> = AllValuesCompatible<
+  ExpandStateDataTypes<StateType>
+>;


### PR DESCRIPTION
Some machines will have heterogeneous state-data that needs to be updated as the machine transitions through states. The `loginMachine` example demonstrates this

```typescript
interface UnauthenticatedState {
  readonly name: "unauthenticated";
}

interface AuthenticatedState {
  readonly name: "authenticated";
  readonly username: string;
  readonly rememberMe: boolean;
}

interface InvalidCredentialsState {
  readonly name: "invalidCredentials";
  readonly errorMessage: string;
}

interface BannedState {
  readonly name: "banned";
}

type LoginState = UnauthenticatedState | AuthenticatedState | InvalidCredentialsState | BannedState;
```

In this case the code defining the machine has to provide explicit `data()` callbacks in the transition config to provide the data for the next state.

In other cases, machines will have homogeneous state-data that is sometimes updated during transitions and sometimes not. In these cases, it's tedious to have to provide explicit `data()` callbacks for every transition when many might not alter the state-data.

The `elevatorMachine` example demonstrates this

```typescript
export interface ElevatorState {
  readonly name: "doorsClosing" | "doorsClosed" | "doorsOpening" | "doorsOpen" | "goingUp" | "goingDown";
  readonly currentFloor: number;
  readonly fractionalFloor: number; // workaround for JS number precision; using two integers instead of a float
  readonly floorsToVisit: readonly number[];
}
```

This change adds a `enableCopyDataOnTransition` option to the machine-definition config that will automatically copy the state data during transitions unless the transition provides an explicit `data()` callback.

```typescript
export const elevatorMachine = defineMachine<ElevatorState, ElevatorEvent>({
  enableCopyDataOnTransition: true, // most transitions don't change the state-data, so copy it by default
  initialState: { name: "doorsClosed", currentFloor: 1, fractionalFloor: 0, floorsToVisit: [] },
  states: {
    doorsClosing: {
      onEnter: sleepThen({ type: "CLOSED_DOORS" }),
      on: {
        OPEN_DOORS: { to: "doorsOpening" },     // no data() callback needed; state-data is copied automatically
        CLOSED_DOORS: { to: "doorsClosed" },    // no data() callback needed; state-data is copied automatically
      },
    },
    // ...
    goingUp: {
      onEnter: sleepThen({ type: "MOVE_UP" }, 500),
      on: {
        MOVE_UP: {
          to: "goingUp",
          data: ({ state }) => ({               // provide data() callback to update state-data
            ...state,
            currentFloor: state.fractionalFloor === 9 ? state.currentFloor + 1 : state.currentFloor,
            fractionalFloor: state.fractionalFloor === 9 ? 0 : state.fractionalFloor + 1,
          }),
        },
      },
    // ...
    },
  },
});
```