### PR TITLE
Sync examples in docs from example source files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,9 @@ jobs:
 
       - name: Test
         run: bun run test:coverage -- --coverage-reporter=lcov --coverage-reporter=text
+
+      - name: Check docs
+        run: |
+          bun run docs:sync -- --skipBundlephobia
+          git diff --exit-code
+        

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -9,7 +9,7 @@ npm install yay-machine         # or your package-manager of choice
 > 💡 View this example's <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/healthMachine.ts" target="_blank">source</a> and <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/__tests__/healthMachine.test.ts" target="_blank">test</a> on GitHub
 
 ```typescript
-import assert from "assert"; 
+import assert from "assert";
 import { defineMachine } from "yay-machine";
 
 type HealthState = Readonly<{
@@ -86,7 +86,7 @@ export const healthMachine = defineMachine<HealthState, HealthEvent>({
           to: "invincible",
           data: ({ state, event }) => applyFirstAid(state, event),
         },
-        DAMAGE: { to: "invincible" },
+        DAMAGE: { to: "invincible", reenter: false },
         HUMAN_AGAIN: { to: "checkHealth", data: ({ state }) => ({ ...state, invincibilityStarted: 0 }) },
       },
     },

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -6,6 +6,8 @@ npm install yay-machine         # or your package-manager of choice
 
 ## Define your machine at compile-time
 
+> 💡 View this example's <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/healthMachine.ts" target="_blank">source</a> and <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/__tests__/healthMachine.test.ts" target="_blank">test</a> on GitHub
+
 ```typescript
 import assert from "assert"; 
 import { defineMachine } from "yay-machine";

--- a/docs/reference/transitions.md
+++ b/docs/reference/transitions.md
@@ -242,6 +242,7 @@ const connection = connectionMachine
       log: console.log.bind(console),
       transport,
       onReceive,
+      lastHeartbeatTime: -1,
     },
   })
   .start();

--- a/docs/reference/transitions.md
+++ b/docs/reference/transitions.md
@@ -10,6 +10,8 @@ We will expand on the "connection machine" example we used when explaining [stat
 
 First, here is the complete machine. In the following sections we explore the various different transition techniques it uses.
 
+> 💡 View this example's <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/connectionMachine.ts" target="_blank">source</a> and <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/__tests__/connectionMachine.test.ts" target="_blank">test</a> on GitHub
+
 ```typescript
 import { defineMachine } from "yay-machine";
 

--- a/packages/example-machines/src/guessMachine.ts
+++ b/packages/example-machines/src/guessMachine.ts
@@ -22,7 +22,9 @@ const incrementNumGuesses = ({ state }: { readonly state: GuessState }): GuessSt
   numGuesses: state.numGuesses + 1,
 });
 
-// guess a number from 1 to 10
+/**
+ * Guess a number from 1 to 10
+ */
 export const guessMachine = defineMachine<GuessState, GuessEvent | NewGameEvent>({
   initialState: { name: "init", answer: 0, numGuesses: 0, maxGuesses: 5 },
   states: {

--- a/packages/yay-machine/README.md
+++ b/packages/yay-machine/README.md
@@ -8,9 +8,9 @@
 
 # Example
 
-<smaller>View this example's <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/guessMachine.ts" target="_blank">source ↗</a> and <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/__tests__/guessMachine.test.ts" target="_blank">test ↗</a> on GitHub</smaller>
-
 ## Define the machine at compile-time
+
+> 💡 View this example's <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/guessMachine.ts" target="_blank">source</a> and <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/__tests__/guessMachine.test.ts" target="_blank">test</a> on GitHub
 
 ```typescript
 import { type CallbackParams, defineMachine } from 'yay-machine';

--- a/packages/yay-machine/README.md
+++ b/packages/yay-machine/README.md
@@ -13,7 +13,8 @@
 > 💡 View this example's <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/guessMachine.ts" target="_blank">source</a> and <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/__tests__/guessMachine.test.ts" target="_blank">test</a> on GitHub
 
 ```typescript
-import { type CallbackParams, defineMachine } from 'yay-machine';
+import assert from "assert";
+import { defineMachine } from "yay-machine";
 
 interface GuessState {
   readonly name: "init" | "playing" | "guessedCorrectly" | "tooManyIncorrectGuesses";
@@ -31,7 +32,7 @@ interface NewGameEvent {
   readonly type: "NEW_GAME";
 }
 
-const incrementNumGuesses = ({ state }: CallbackParams<GuessState, GuessEvent>): GuessState => ({
+const incrementNumGuesses = ({ state }: { readonly state: GuessState }): GuessState => ({
   ...state,
   numGuesses: state.numGuesses + 1,
 });
@@ -86,9 +87,10 @@ while (guess.state.name === "playing") {
 
 if (guess.state.name === "guessedCorrectly") {
   console.log("yay, we won :)");
-}
-if (guess.state.name === "tooManyIncorrectGuesses") {
+} else if (guess.state.name === "tooManyIncorrectGuesses") {
   console.log("boo, we lost :(");
+} else {
+  assert.fail(`Invalid state: ${guess.state.name}`);
 }
 ```
 

--- a/packages/yay-machine/README.md
+++ b/packages/yay-machine/README.md
@@ -8,6 +8,8 @@
 
 # Example
 
+<smaller>View this example's <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/guessMachine.ts" target="_blank">source ↗</a> and <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/__tests__/guessMachine.test.ts" target="_blank">test ↗</a> on GitHub</smaller>
+
 ## Define the machine at compile-time
 
 ```typescript

--- a/scripts/sync-docs.ts
+++ b/scripts/sync-docs.ts
@@ -83,7 +83,7 @@ for (const file of await readdir(docsDir, { recursive: true, withFileTypes: true
   if (!file.isFile()) {
     continue;
   }
-  if (file.name.startsWith("assets") || !file.name.endsWith(".md")) {
+  if (!file.name.endsWith(".md")) {
     continue;
   }
 

--- a/scripts/sync-docs.ts
+++ b/scripts/sync-docs.ts
@@ -118,7 +118,6 @@ for (const fileName of files) {
       log("found embedded example", exampleFile);
       const exampleSource = await readFile(exampleFile, { encoding: "utf8" });
       const [definition, usage] = exampleSource.split("// Usage").map((it) => it.trim());
-      log(`${exampleFile} has definition:\n\n${definition}\n\nUsage:\n\n${usage}`);
 
       const startDefinition = newContent.indexOf("```typescript", index);
       const endDefinition = newContent.indexOf("```", startDefinition + 3);

--- a/scripts/sync-docs.ts
+++ b/scripts/sync-docs.ts
@@ -15,6 +15,7 @@ const metadataFile = `${assetsDir}/bundlephobia-metadata.json`;
 
 const args = process.argv.slice(2);
 const dryRun = args.includes("--dryRun");
+const skipBundlephobia = args.includes("--skipBundlephobia");
 
 // biome-ignore lint/suspicious/noExplicitAny: CLI output
 const log = (message: string, ...args: any[]) => console.log(message, ...args);
@@ -76,20 +77,18 @@ const captureBundlephobiaStats = async (): Promise<PackagesMetadata> => {
 const previousMetadata = await readMetadata();
 log("previous metadata", previousMetadata, indexMetadata(previousMetadata));
 
-const newMetadata = await captureBundlephobiaStats();
+const newMetadata = skipBundlephobia ? previousMetadata : await captureBundlephobiaStats();
 
 let didChange = false;
-for (const file of await readdir(docsDir, { recursive: true, withFileTypes: true })) {
-  if (!file.isFile()) {
-    continue;
-  }
-  if (!file.name.endsWith(".md")) {
-    continue;
-  }
-
-  const fileName = `${file.parentPath}/${file.name}`;
-  const content = (await readFile(fileName, { encoding: "utf8" })).toString();
+const files = (await readdir(docsDir, { recursive: true, withFileTypes: true }))
+  .filter((it) => it.isFile() && it.name.endsWith(".md"))
+  .map((it) => `${it.parentPath}/${it.name}`)
+  .concat(["packages/yay-machine/README.md"]);
+for (const fileName of files) {
   log(fileName);
+  const content = (await readFile(fileName, { encoding: "utf8" })).toString();
+
+  // update any scraped text
   let newContent = content;
   for (const [text, [packageName, key]] of Object.entries(indexMetadata(previousMetadata))) {
     if (newContent.includes(text)) {
@@ -100,6 +99,43 @@ for (const file of await readdir(docsDir, { recursive: true, withFileTypes: true
       log(`${fileName}: "${text}" => "${replacement}`);
       newContent = newContent.replaceAll(text, replacement);
       didChange = true;
+    }
+  }
+
+  // update example code
+  /*
+  > 💡 View this example's <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/healthMachine.ts" target="_blank">source</a> and <a href="https://github.com/maurice/yay-machine/blob/main/packages/example-machines/src/__tests__/healthMachine.test.ts" target="_blank">test</a> on GitHub
+  */
+  const index = newContent.indexOf("> 💡 View this example's <a href");
+  if (index !== -1) {
+    const result = newContent.match(
+      /View this example's <a href="https:\/\/github.com\/maurice\/yay-machine\/blob\/main\/([^"]+)" target="_blank"/,
+    );
+    if (!result) {
+      log(`${fileName}: seems corrupted - no example match`);
+    } else {
+      const exampleFile = result[1];
+      log("found embedded example", exampleFile);
+      const exampleSource = await readFile(exampleFile, { encoding: "utf8" });
+      const [definition, usage] = exampleSource.split("// Usage").map((it) => it.trim());
+      log(`${exampleFile} has definition:\n\n${definition}\n\nUsage:\n\n${usage}`);
+
+      const startDefinition = newContent.indexOf("```typescript", index);
+      const endDefinition = newContent.indexOf("```", startDefinition + 3);
+      const startUsage = newContent.indexOf("```typescript", endDefinition + 3);
+      const endUsage = newContent.indexOf("```", startUsage + 3);
+
+      newContent = [
+        newContent.slice(0, startDefinition),
+        "```typescript\n",
+        definition,
+        "\n",
+        newContent.slice(endDefinition, startUsage),
+        "```typescript\n",
+        usage,
+        "\n",
+        newContent.slice(endUsage),
+      ].join("");
     }
   }
 


### PR DESCRIPTION
This change adds tooling to automate keeping the examples in the docs (markdown files) up-to-date.

`scripts/sync-docs` now searches the docs for "💡 View this example..." (links to GitHub) then extracts the example's filename and updates the source code in the docs from the file.

It should also fail the build when the docs are out-of-date vs example sources, so examples in READMEs etc should be working from now on.