### PR TITLE
docs: link directly to GitHub pages from `yay-machine` package README.md

### DIFF
--- a/docs/nav.md
+++ b/docs/nav.md
@@ -15,4 +15,4 @@
 
 * [Why state-machines?](./articles/why-state-machines.md)
 * [Why **yay-machine**?](./articles/why-yay-machine.md)
-* [vs **XState**?](./articles/vs-xstate.md)
+* [vs **XState**](./articles/vs-xstate.md)

--- a/packages/yay-machine/README.md
+++ b/packages/yay-machine/README.md
@@ -107,9 +107,9 @@ if (guess.state.name === "guessedCorrectly") {
 
 # Next...
 
-* [About **yay-machine**](https://github.com/maurice/yay-machine/blob/main/docs/about.md)
-* [Quick Start](https://github.com/maurice/yay-machine/blob/main/docs/quick-start.md)
-* [Reference docs](https://github.com/maurice/yay-machine/blob/main/docs/reference/state.md)
-* [Why state-machines?](https://github.com/maurice/yay-machine/blob/main/docs/articles/why-state-machines.md)
-* [Why **yay-machine**?](https://github.com/maurice/yay-machine/blob/main/docs/articles/why-yay-machine.md)
-* [**yay-machine** vs **XState**?](https://github.com/maurice/yay-machine/blob/main/docs/articles/vs-xstate.md)
+* [About **yay-machine**](https://maurice.github.io/yay-machine/)
+* [Quick Start](https://maurice.github.io/yay-machine/quick-start.html)
+* [Reference docs](https://maurice.github.io/yay-machine/reference/state.html)
+* [Why state-machines?](https://maurice.github.io/yay-machine/articles/why-state-machines.html)
+* [Why **yay-machine**?](https://maurice.github.io/yay-machine/articles/why-yay-machine.html)
+* [**yay-machine** vs **XState**](https://maurice.github.io/yay-machine/articles/vs-xstate.html)


### PR DESCRIPTION
This README.md is published with the package and welcomes people on `npmjs.com` so I think the best place to send them is now the GitHub pages versions of the docs.

They are already better (IMHO) than the vanilla GitHub pages experience, and they can be made even better over time.