### PR TITLE
docs: fix broken link and wrong doc header

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@
 * [Login](./examples/login.md)
 * [Health (game component)](./examples/health.md)
 * [Tape (VCR)](./examples/tape.md)
-* [STOMP Frame parser](./examples/stomp-parser.md)
+* [STOMP parser](./examples/stomp-parser.md)
 * [Elevator](./examples/elevator.md)
 * [Elevators controller](./examples/elevators-controller.md)
 

--- a/docs/examples/elevator.md
+++ b/docs/examples/elevator.md
@@ -9,11 +9,11 @@
 
 ## About
 
-This example models an elevator (lift). This model operates completely standalone, but can also be combined into a group of coordinated elevators using the [elevator controller](./elevator-controller.md).
+This example models an elevator (lift). This model operates completely standalone, but can also be combined into a group of coordinated elevators with the [elevators controller](./elevators-controller.md).
 
-The elevator machine's state says where it is now and where it's going, plus it has a queue of floors to visit next (if any). When a `VISIT_FLOOR` event is received (either by summoning it at the wall, or a passenger pressing a button inside), the elevator either opens the doors (if already at the floor), else adds the floor to its queue at the best position.
+The elevator machine's state says where it is now and where it's going, plus it has a queue of floors to visit next (if any). When a `VISIT_FLOOR` event is received (either by summoning it at the wall, or a passenger pressing a button inside), the elevator either opens the doors (if already at the floor), else adds the floor to its queue.
 
-State `onEntry()` side-effects use `setTimeout` to send events to the machine to simulate 5s to open/close doors. Similarly we simulate travel (up/down) progress by moving 1/10th of a floor every 500ms, meaning it takes 5s to go up/down one floor.
+State `onEntry()` side-effects use `setTimeout` to send events to the machine to simulate 5s to open/close doors. Similarly up/down travel progress is simulated by moving 1/10th of a floor every 500ms, meaning it takes 5s to go up/down one floor.
 
 This machine's state data is homogenous and we're using `enableCopyDataOnTransition` to simplify some transitions that don't update the data.
 

--- a/docs/examples/stomp-parser.md
+++ b/docs/examples/stomp-parser.md
@@ -1,4 +1,4 @@
-# Toggle (on/off)
+# STOMP parser
 
 > 🏷️ `state data`\
 > 🏷️ `conditional transitions`\
@@ -7,11 +7,9 @@
 
 ## About
 
-A parser in the form of a state-machine.
+This machine parses [STOMP messages](https://stomp.github.io/), as [defined by the spec](https://stomp.github.io/stomp-specification-1.2.html). This parser roughly mirrors the [Augmented BNF](https://stomp.github.io/stomp-specification-1.2.html#Augmented_BNF).
 
-This machine parses STOMP Frames, which are text messages with a COMMAND, optional headers and body, as [defined by the spec](https://stomp.github.io/stomp-specification-1.2.html). This parser roughly mirrors the [Augmented BNF](https://stomp.github.io/stomp-specification-1.2.html#Augmented_BNF).
-
-The machine starts in the `idle` state, and when it receives a `PARSE` event it proceeds to consume input until either landing in the `error` state or one of the `command:client` or `command:server` states. If the raw text data contains more frames it loops around until all input is consumed.
+The machine starts in the `idle` state, and when it receives a `PARSE` event, it consumes input until landing in either the `error` state or one of the `command:client` or `command:server` states. If the raw text data contains more messages, it loops around until all input is consumed.
 
 As it finds valid tokens it keeps advancing the state's `currentIndex`, which is the current parse position in the `raw` message `string`.
 


### PR DESCRIPTION
closes #73
