### PR TITLE
feat: add exports map to package.json for proper ESM resolution

### DIFF
--- a/packages/yay-machine/package.json
+++ b/packages/yay-machine/package.json
@@ -6,6 +6,14 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    }
+  },
   "files": [
     "src",
     "dist"


### PR DESCRIPTION
This commit introduces the "exports" field to the `package.json` of the `yay-machine` package.

The "exports" map ensures that Node.js and modern build tools correctly resolve the ES Module (ESM) build of `yay-machine` when it's imported in ESM projects. This is particularly important when dependencies use "exports" maps, which can alter module resolution behavior.

The map includes conditional exports for:
- "types": Points to the TypeScript declaration file.
- "import": Points to the ESM build (`dist/index.js`).
- "require": Points to the CommonJS build (`dist/index.cjs`).
- "default": Also points to the ESM build as a fallback.

The existing "main", "module", and "types" fields are retained for compatibility with older tools and Node.js versions that do not fully support the "exports" field.